### PR TITLE
Add carrier demodulation support for ESP-IDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,26 @@ i2cx2:
     scan: true
 ```
 
+## Remote receiver with carrier demodulation
 
+On supported ESP32 chips, the [RMT peripheral][esp-idf-esp32c3-rmt] supports
+carrier demodulation. This functionality is exposed via ESP-IDF.
+
+Carrier demodulation is available in the `remote_receiver` component via two new
+configuration keys, `carrier_duty_percent` and `carrier_frequency`. To enable
+carrier demodulation, simple set these values:
+
+```yaml
+remote_receiver:
+- id: ...
+  carrier_duty_percent: 25%
+  carrier_frequency: 25000 Hz
+```
+
+The ESP-IDF RMT documentation suggests a demodulation carrier frequency of
+25000 Hz for infrared signals transmitted at 38000 Hz.
+
+
+[esp-idf-esp32c3-rmt]: https://docs.espressif.com/projects/esp-idf/en/stable/esp32c3/api-reference/peripherals/rmt.html
 [esphome-issue-1699]: https://github.com/esphome/feature-requests/issues/1699
 [so-i2c-multiplex-curcuit]: https://electronics.stackexchange.com/a/209031

--- a/esphome/components/remote_receiver/__init__.py
+++ b/esphome/components/remote_receiver/__init__.py
@@ -4,6 +4,8 @@ from esphome.components import esp32_rmt, remote_base
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_BUFFER_SIZE,
+    CONF_CARRIER_DUTY_PERCENT,
+    CONF_CARRIER_FREQUENCY,
     CONF_CLOCK_DIVIDER,
     CONF_CLOCK_RESOLUTION,
     CONF_DUMP,
@@ -90,6 +92,14 @@ CONFIG_SCHEMA = remote_base.validate_triggers(
         {
             cv.GenerateID(): cv.declare_id(RemoteReceiverComponent),
             cv.Required(CONF_PIN): cv.All(pins.internal_gpio_input_pin_schema),
+            cv.SplitDefault(CONF_CARRIER_DUTY_PERCENT, esp32_idf=33): cv.All(
+                cv.only_with_esp_idf,
+                cv.percentage_int,
+                cv.Range(min=1, max=100),
+            ),
+            cv.SplitDefault(CONF_CARRIER_FREQUENCY, esp32_idf="0Hz"): cv.All(
+                cv.only_with_esp_idf, cv.frequency, cv.int_
+            ),
             cv.Optional(CONF_DUMP, default=[]): remote_base.validate_dumpers,
             cv.Optional(CONF_TOLERANCE, default="25%"): validate_tolerance,
             cv.SplitDefault(
@@ -158,6 +168,8 @@ async def to_code(config):
                 cg.add(var.set_clock_resolution(config[CONF_CLOCK_RESOLUTION]))
             if CONF_FILTER_SYMBOLS in config:
                 cg.add(var.set_filter_symbols(config[CONF_FILTER_SYMBOLS]))
+            cg.add(var.set_carrier_duty_percent(config[CONF_CARRIER_DUTY_PERCENT]))
+            cg.add(var.set_carrier_frequency(config[CONF_CARRIER_FREQUENCY]))
         else:
             if (rmt_channel := config.get(CONF_RMT_CHANNEL, None)) is not None:
                 var = cg.new_Pvariable(

--- a/esphome/components/remote_receiver/remote_receiver.h
+++ b/esphome/components/remote_receiver/remote_receiver.h
@@ -73,6 +73,8 @@ class RemoteReceiverComponent : public remote_base::RemoteReceiverBase,
   void set_filter_symbols(uint32_t filter_symbols) { this->filter_symbols_ = filter_symbols; }
   void set_receive_symbols(uint32_t receive_symbols) { this->receive_symbols_ = receive_symbols; }
   void set_with_dma(bool with_dma) { this->with_dma_ = with_dma; }
+  void set_carrier_duty_percent(uint8_t carrier_duty_percent) { this->carrier_duty_percent_ = carrier_duty_percent; }
+  void set_carrier_frequency(uint32_t carrier_frequency) { this->carrier_frequency_ = carrier_frequency; }
 #endif
   void set_buffer_size(uint32_t buffer_size) { this->buffer_size_ = buffer_size; }
   void set_filter_us(uint32_t filter_us) { this->filter_us_ = filter_us; }
@@ -86,6 +88,8 @@ class RemoteReceiverComponent : public remote_base::RemoteReceiverBase,
   uint32_t filter_symbols_{0};
   uint32_t receive_symbols_{0};
   bool with_dma_{false};
+  uint32_t carrier_frequency_{38000};
+  uint8_t carrier_duty_percent_{100};
 #else
   void decode_rmt_(rmt_item32_t *item, size_t item_count);
   RingbufHandle_t ringbuf_;

--- a/esphome/components/remote_receiver/remote_receiver_esp32.cpp
+++ b/esphome/components/remote_receiver/remote_receiver_esp32.cpp
@@ -76,6 +76,21 @@ void RemoteReceiverComponent::setup() {
     return;
   }
 
+  if (this->carrier_frequency_ > 0 && 0 < this->carrier_duty_percent_ && this->carrier_duty_percent_ < 100) {
+    rmt_carrier_config_t carrier;
+    memset(&carrier, 0, sizeof(carrier));
+    carrier.frequency_hz = this->carrier_frequency_;
+    carrier.duty_cycle = (float) this->carrier_duty_percent_ / 100.0f;
+    carrier.flags.polarity_active_low = this->pin_->is_inverted();
+    error = rmt_apply_carrier(this->channel_, &carrier);
+    if (error != ESP_OK) {
+      this->error_code_ = error;
+      this->error_string_ = "in rmt_apply_carrier";
+      this->mark_failed();
+      return;
+    }
+  }
+
   rmt_rx_event_callbacks_t callbacks;
   memset(&callbacks, 0, sizeof(callbacks));
   callbacks.on_recv_done = rmt_callback;
@@ -161,6 +176,10 @@ void RemoteReceiverComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "Remote Receiver:");
   LOG_PIN("  Pin: ", this->pin_);
 #if ESP_IDF_VERSION_MAJOR >= 5
+  if (this->carrier_frequency_ > 0 && 0 < this->carrier_duty_percent_ && this->carrier_duty_percent_ < 100) {
+    ESP_LOGCONFIG(TAG, "  Carrier Frequency: %" PRIu32 " hz", this->carrier_frequency_);
+    ESP_LOGCONFIG(TAG, "  Carrier Duty: %u%%", this->carrier_duty_percent_);
+  }
   ESP_LOGCONFIG(TAG, "  Clock resolution: %" PRIu32 " hz", this->clock_resolution_);
   ESP_LOGCONFIG(TAG, "  RMT symbols: %" PRIu32, this->rmt_symbols_);
   ESP_LOGCONFIG(TAG, "  Filter symbols: %" PRIu32, this->filter_symbols_);

--- a/tests/components/remote_receiver/test.esp32-idf.yaml
+++ b/tests/components/remote_receiver/test.esp32-idf.yaml
@@ -1,6 +1,8 @@
 substitutions:
   pin: GPIO2
   clock_resolution: "2000000"
+  carrier_duty_percent: "25"
+  carrier_frequency: "30000"
   filter_symbols: "2"
   receive_symbols: "4"
   rmt_symbols: "64"


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
remote_receiver:
- id: ...
  carrier_duty_percent: 25%
  carrier_frequency: 25000 Hz
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
